### PR TITLE
fixed test data path bug

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -11,7 +11,7 @@ env:
   TAG_VERSION: 0.1.0
 
 jobs:
-  test:
+  pytest:
     runs-on: ubuntu-latest
 
     steps:

--- a/wizards_staff/gcp.py
+++ b/wizards_staff/gcp.py
@@ -41,7 +41,7 @@ def download_gcp_dir(bucket_name: str, prefix: str, outdir: str=None):
         blob.download_to_filename(local_path)
     
     # Return the output directory
-    return os.path.join(outdir, prefix)
+    return outdir
 
 # Example usage
 def main():


### PR DESCRIPTION
This pull request includes changes to the CI/CD workflow and a minor modification in the GCP utility function.

Changes to CI/CD workflow:

* [`.github/workflows/ci-cd.yaml`](diffhunk://#diff-8ed13df95e3667964f78d1711225fae3857dfa8a46481166740dd4a28920331fL14-R14): Renamed the job from `test` to `pytest` to better reflect the purpose of the job.

Changes to GCP utility function:

* [`wizards_staff/gcp.py`](diffhunk://#diff-7d76132480ed79dc7f4fdbe79b73b1949a23f6fc013641fdf270c635ea6e0cf3L44-R44): Modified the `download_gcp_dir` function to return the `outdir` directly instead of joining it with the `prefix`.