### PR TITLE
Disable multithreading for NumPy to  prevent stalling during deconvol…

### DIFF
--- a/wizards_staff/__init__.py
+++ b/wizards_staff/__init__.py
@@ -1,3 +1,9 @@
-from .wizards.orb import Orb
+# disable multithreading for numpy
+import os
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["MKL_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
 
+# import the Orb class
+from .wizards.orb import Orb
 __all__ = ['Orb']


### PR DESCRIPTION
Disable multithreading for NumPy to  prevent stalling during deconvolution.foopsi